### PR TITLE
Update Java version to 1.8 and change deprecated property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>17</java.version>
+		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,4 @@ spring.datasource.url=jdbc:mysql://$AZ_DATABASE_NAME.mysql.database.azure.com:33
 spring.datasource.username=spring@$AZ_DATABASE_NAME
 spring.datasource.password=$AZ_MYSQL_PASSWORD
 
-spring.datasource.initialization-mode=always
+spring.sql.init.mode=always


### PR DESCRIPTION
## Purpose
- Many Java applications still use Java8, and if users' JDK is lower than Java17, the application will fail to run. But if we change the compilatiohn version to 1.8, it will work with JDK 8 and above. 
- The `spring.datasource.initialization-mode=always` has been deprecated, use `spring.sql.init.mode=always` instead.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->